### PR TITLE
Integrate rt-recon-sdk: add InfluxDB autoconfiguration support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.16)
 
 project(rtu_jammer
   VERSION 1.0
@@ -6,15 +6,33 @@ project(rtu_jammer
   LANGUAGES CXX
 )
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake/modules")
 
+# ---------------------------------------------------------------------------
+# Fetch rt-recon-sdk
+# ---------------------------------------------------------------------------
+include(FetchContent)
 
+FetchContent_Declare(
+  rt-recon-sdk
+  # GIT_REPOSITORY https://github.com/cueltschey/rt-recon-sdk.git
+  SOURCE_DIR /home/niraj-gupta/Documents/wireless/rt-recon-sdk
+  # GIT_TAG        main
+  # GIT_SHALLOW    TRUE
+)
+
+message(STATUS "Fetching rt-recon-sdk from GitHub...")
+FetchContent_MakeAvailable(rt-recon-sdk)
+
+# ---------------------------------------------------------------------------
+# Existing dependencies
+# ---------------------------------------------------------------------------
 find_package(UHD)
 if(UHD_FOUND)
-  set(RF_FOUND true)
   include_directories(${UHD_INCLUDE_DIRS})
   link_directories(${UHD_LIBRARY_DIRS})
   message(STATUS "UHD library found")
@@ -23,20 +41,48 @@ else()
 endif()
 
 find_package(YAMLCPP)
-if (YAMLCPP_FOUND)
+if(YAMLCPP_FOUND)
   include_directories(${YAMLCPP_INCLUDE_DIR})
-  link_directories(${YAMLCPP_LIBRARY})
-else (YAMLCPP_FOUND)
+else()
   message(FATAL_ERROR "yaml-cpp is required to build ${CMAKE_PROJECT_NAME}")
-endif (YAMLCPP_FOUND)
+endif()
 
+# ---------------------------------------------------------------------------
+# srsRAN 4G libs needed by rt-recon-autoconfig
+# (srsran_phch does not exist as a separate lib — merged into srsran_phy)
+# ---------------------------------------------------------------------------
+find_library(SRSRAN_PHY_LIB    NAMES srsran_phy    REQUIRED)
+find_library(SRSRAN_COMMON_LIB NAMES srsran_common  REQUIRED)
+find_library(SUPPORT_LIB       NAMES support        REQUIRED)
+find_library(SRSLOG_LIB        NAMES srslog         REQUIRED)
+find_library(SRSRAN_RF_LIB     NAMES srsran_rf      REQUIRED)
 
+message(STATUS "SRSRAN_PHY_LIB:    ${SRSRAN_PHY_LIB}")
+message(STATUS "SRSRAN_COMMON_LIB: ${SRSRAN_COMMON_LIB}")
+message(STATUS "SUPPORT_LIB:       ${SUPPORT_LIB}")
+message(STATUS "SRSLOG_LIB:        ${SRSLOG_LIB}")
+message(STATUS "SRSRAN_RF_LIB:     ${SRSRAN_RF_LIB}")
+
+# ---------------------------------------------------------------------------
+# Build jammer
+# ---------------------------------------------------------------------------
 file(GLOB JAMMER_SRC src/*.cc)
 
 include_directories(hdr)
 add_executable(jammer ${JAMMER_SRC})
 
-target_link_libraries(jammer ${UHD_LIBRARIES} yaml-cpp)
+target_link_libraries(jammer
+  PRIVATE
+    ${UHD_LIBRARIES}
+    yaml-cpp
+    rt-recon-autoconfig
+    ${SRSRAN_PHY_LIB}
+    ${SRSRAN_COMMON_LIB}
+    ${SUPPORT_LIB}
+    ${SRSLOG_LIB}
+    ${SRSRAN_RF_LIB}
+    pthread
+)
 
 install(
   PROGRAMS

--- a/configs/autoconfig_jammer.yaml
+++ b/configs/autoconfig_jammer.yaml
@@ -1,0 +1,32 @@
+
+
+
+enable_autoconfigure: true
+
+
+
+#database configuration
+database:
+  host: "127.0.0.1"
+  port: 8086
+  org: "rtu"
+  token: "605bc59413b7d5457d181ccf20f9fda15693f81b068d70396cc183081b264f3b"
+  bucket: "rtusystem"
+  data_id: "test"
+
+
+amplitude: 0.7
+amplitude_width: 0.05
+center_frequency: 3.619200e9
+bandwidth: 40e6
+initial_phase: 0
+sampling_freq: 46.080000e6
+num_samples: 20000
+output_iq_file: "output.fc32"
+output_csv_file: "output.csv"
+write_iq: false
+write_csv: true
+device_args: "type=b200"
+tx_gain: 89.5
+
+

--- a/hdr/args.h
+++ b/hdr/args.h
@@ -4,11 +4,24 @@
 #include <cstring>
 #include <iostream>
 #include <yaml-cpp/yaml.h>
+#include <string>
 
 typedef struct rf_args_s {
   std::string device_args;
   float tx_gain;
 } rf_args_t;
+
+
+//influx_db
+
+typedef struct db_args_s {
+  std::string host = "127.0.0.1";
+  uint32_t    port = 8086;
+  std::string org  = "";
+  std::string token = "";
+  std::string bucket = "";
+  std::string data_id = "";
+} db_args_t;
 
 typedef struct all_args_s {
   float amplitude;
@@ -23,6 +36,10 @@ typedef struct all_args_s {
   bool write_iq;
   bool write_csv;
   rf_args_t rf;
+
+  //autoconfig control
+  bool enable_autoconfigure = false;
+  db_args_t db;
 } all_args_t;
 
 all_args_t parseConfig(const std::string &filename);

--- a/hdr/autoconfig.h
+++ b/hdr/autoconfig.h
@@ -1,0 +1,8 @@
+#ifndef AUTOCONFIG_H
+#define AUTOCONFIG_H
+
+#include "args.h"
+
+bool applyInfluxAutoconfig(all_args_t& args);
+
+#endif

--- a/src/args.cc
+++ b/src/args.cc
@@ -15,31 +15,58 @@ all_args_t parseConfig(
   REQUIRE_FIELD(config, amplitude);
   REQUIRE_FIELD(config, num_samples);
   REQUIRE_FIELD(config, amplitude_width);
-  REQUIRE_FIELD(config, center_frequency);
+ // REQUIRE_FIELD(config, center_frequency);
   REQUIRE_FIELD(config, bandwidth);
   REQUIRE_FIELD(config, initial_phase);
-  REQUIRE_FIELD(config, sampling_freq);
+ // REQUIRE_FIELD(config, sampling_freq);
   REQUIRE_FIELD(config, output_iq_file);
   REQUIRE_FIELD(config, output_csv_file);
   REQUIRE_FIELD(config, write_iq);
   REQUIRE_FIELD(config, write_csv);
   REQUIRE_FIELD(config, device_args);
-  REQUIRE_FIELD(config, tx_gain);
+ // REQUIRE_FIELD(config, tx_gain);
 
   all_args_t args; // an instance of struct
   args.amplitude        = config["amplitude"].as<float>();
   args.num_samples      = config["num_samples"].as<size_t>();
   args.amplitude_width  = config["amplitude_width"].as<float>();
-  args.center_frequency = config["center_frequency"].as<float>();
+ // args.center_frequency = config["center_frequency"].as<float>();
   args.bandwidth        = config["bandwidth"].as<float>();
   args.initial_phase    = config["initial_phase"].as<float>();
-  args.sampling_freq    = config["sampling_freq"].as<float>();
+ // args.sampling_freq    = config["sampling_freq"].as<float>();
   args.output_iq_file   = config["output_iq_file"].as<std::string>();
   args.output_csv_file  = config["output_csv_file"].as<std::string>();
   args.write_iq         = config["write_iq"].as<bool>();
   args.write_csv        = config["write_csv"].as<bool>();
   args.rf.device_args   = config["device_args"].as<std::string>();
-  args.rf.tx_gain       = config["tx_gain"].as<float>();
+ // args.rf.tx_gain       = config["tx_gain"].as<float>();
+
+
+  // These three are optional — autoconfig will supply them if enable_autoconfigure is true
+  args.center_frequency = config["center_frequency"] ? config["center_frequency"].as<float>() : 0.0f;
+  args.sampling_freq    = config["sampling_freq"]    ? config["sampling_freq"].as<float>()    : 0.0f;
+  args.rf.tx_gain       = config["tx_gain"]          ? config["tx_gain"].as<float>()          : 0.0f;
+//  
+
+  // autoconfig field
+  args.enable_autoconfigure = false;
+  if (config["enable_autoconfigure"]) {
+	  args.enable_autoconfigure = config["enable_autoconfigure"].as<bool>();
+  }
+  if (config["database"]){
+	YAML::Node db = config["database"];
+	if (db["host"]) args.db.host = db["host"].as<std::string>();
+	
+	if (db["port"]) args.db.port = db["port"].as<uint32_t>();
+	
+	if (db["org"]) args.db.org = db["org"].as<std::string>();
+
+	if (db["token"]) args.db.token = db["token"].as<std::string>();
+
+	if (db["bucket"]) args.db.bucket = db["bucket"].as<std::string>();
+
+	if (db["data_id"]) args.db.data_id = db["data_id"].as<std::string>();
+  } 
   return args;
 }
 
@@ -77,6 +104,9 @@ void overrideConfig(all_args_t &args, int argc, char *argv[]) {
       ++i;
     } else if (std::strcmp(argv[i], "--tx_gain") == 0 && i + 1 < argc) {
       args.rf.tx_gain = std::stof(argv[++i]);
+	
+    } else if (std::strcmp(argv[i], "--enable_autoconfigure") == 0 && i + 1 < argc) {
+      args.enable_autoconfigure = (std::string(argv[++i]) == "true");
     } else {
       std::cerr << "Unknown or incomplete option: " << argv[i] << std::endl;
     }

--- a/src/autoconfig.cc
+++ b/src/autoconfig.cc
@@ -1,0 +1,52 @@
+#include "autoconfig.h"
+#include "rt-recon-sdk/autoconfig/influx_worker.h"
+#include "rt-recon-sdk/autoconfig/logger.h"
+#include <iostream>
+
+bool applyInfluxAutoconfig(all_args_t& args)
+{
+  logger_init(1);
+  logger_set_level(LOG_INFO);
+  rtrs::DatabaseConfig db_cfg;
+  db_cfg.host = args.db.host;
+  db_cfg.port = args.db.port;
+  db_cfg.org = args.db.org;
+  db_cfg.token = args.db.token;
+  db_cfg.bucket = args.db.bucket;
+  db_cfg.data_id = args.db.data_id;
+
+  rtrs::InfluxWorker influx(db_cfg);
+
+
+  // tx_gain, tx_red, offsets
+  rtrs::ChannelConfig ch;
+  if (!influx.pull_msg(ch))
+  {
+    std::cerr << "[autoconfig] Failed to pull channelConfig from InfluxDB\n";
+    return false;
+  }
+
+
+  // frq, sample_rate. scs
+  rtrs::recon_band_report_t band;
+  if(!influx.pull_msg(band))
+  {
+    std::cerr << "[autoconfig] Failed to pull band report from InfluxDB\n";
+    return false;
+  }
+
+
+  // map to jammer args
+  args.center_frequency = static_cast<float>(band.ssb_freq);
+  args.sampling_freq = static_cast<float>(band.sample_rate);
+  args.rf.tx_gain = static_cast<float>(ch.tx_gain);
+
+
+  std::cout << "[autoconfig] center_frequency : " << args.center_frequency << "\n";
+  
+  std::cout << "[autoconfig] sampling_frequency : " << args.sampling_freq << "\n";
+
+  std::cout << "[autoconfig] tx_gain : " << args.rf.tx_gain << "\n";
+  return true;
+}
+

--- a/src/main.cc
+++ b/src/main.cc
@@ -1,6 +1,7 @@
 #include <cstdio>
 #include <iostream>
 
+#include "autoconfig.h"
 #include "args.h"
 #include "noise.h"
 #include "rf.h"
@@ -74,8 +75,28 @@ int main(int argc, char *argv[]) {
   // Load config from YAML
   all_args_t args = parseConfig(config_file);
 
+  // pull data from influx db if the autoconfig is true
+
+  if (args.enable_autoconfigure)
+  {
+     if(!applyInfluxAutoconfig(args))
+     {
+        fprintf(stderr, "Autoconfig from InfluxDB failed\n");
+	return EXIT_FAILURE;
+     }
+  }
+
+
   // Override config with any command-line arguments provided
   overrideConfig(args, argc, argv);
+
+
+  // Validate that RF fields were provided (either from YAML or autoconfig)
+  if (args.center_frequency == 0.0f || args.sampling_freq == 0.0f || args.rf.tx_gain == 0.0f) {
+    fprintf(stderr, "Error: center_frequency, sampling_freq, and tx_gain must be set "
+                    "(either in YAML or via autoconfig)\n");
+    return EXIT_FAILURE;
+  }
 
   // Generate the complex sine wave
   auto samples = generateComplexSineWave(args);


### PR DESCRIPTION
- Add FetchContent for rt-recon-sdk in CMakeLists.txt
- Add db_args_t struct and enable_autoconfigure flag to args.h
- Make center_frequency, sampling_freq, tx_gain optional in args.cc
- Add autoconfig.h and autoconfig.cc using InfluxWorker to pull config
- Wire applyInfluxAutoconfig into main.cc
- Add autoconfig_jammer.yaml example config